### PR TITLE
Implement sidebar navigation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,7 @@ let package = Package(
             path: "Things4",
             exclude: [
                 "Assets.xcassets",
-                "ContentView.swift",
-                "Things4App.swift",
+                "Sources",
                 "Things4.entitlements"
             ],
             sources: [

--- a/Things4/Sources/MyApp/ContentView.swift
+++ b/Things4/Sources/MyApp/ContentView.swift
@@ -1,21 +1,72 @@
-//
-//  ContentView.swift
-//  Things4
-//
-//  Created by Aidan O'Brien on 17/06/2025.
-//
-
 import SwiftUI
+import Things4
 
 struct ContentView: View {
+    @State private var selection: ListSelection?
+    @StateObject private var store = DatabaseStore()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        #if os(iOS)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            splitView
+        } else {
+            stackView
         }
-        .padding()
+        #else
+        splitView
+        #endif
+    }
+
+    private var splitView: some View {
+        NavigationSplitView(selection: $selection) {
+            sidebar
+        } detail: {
+            detail
+        }
+    }
+
+    private var stackView: some View {
+        NavigationStack(path: $selection) {
+            sidebar
+                .navigationDestination(for: ListSelection.self) { sel in
+                    ToDoListView(store: store, selection: sel)
+                }
+        }
+    }
+
+    private var sidebar: some View {
+        List(selection: $selection) {
+            Section("Lists") {
+                ForEach(DefaultList.allCases) { list in
+                    NavigationLink(value: ListSelection.list(list)) {
+                        Label(list.title, systemImage: "list.bullet")
+                    }
+                }
+            }
+            Section("Areas") {
+                ForEach(store.database.areas) { area in
+                    let areaProjects = store.database.projects.filter { $0.parentAreaID == area.id }
+                    if areaProjects.isEmpty {
+                        NavigationLink(value: ListSelection.area(area.id)) { Text(area.title) }
+                    } else {
+                        DisclosureGroup(area.title) {
+                            ForEach(areaProjects) { project in
+                                NavigationLink(value: ListSelection.project(project.id)) { Text(project.title) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var detail: some View {
+        if let selection {
+            ToDoListView(store: store, selection: selection)
+        } else {
+            Text("Select a list")
+                .navigationTitle("Things4")
+        }
     }
 }
 

--- a/Things4/Sources/MyApp/DatabaseStore.swift
+++ b/Things4/Sources/MyApp/DatabaseStore.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import Things4
+
+@MainActor
+final class DatabaseStore: ObservableObject {
+    @Published var database: Database = .init()
+
+    init() {
+        Task {
+            do {
+                database = try await PersistenceManager.shared.load()
+                if database.areas.isEmpty && database.projects.isEmpty && database.toDos.isEmpty {
+                    database = SampleData.database
+                }
+            } catch {
+                database = SampleData.database
+            }
+        }
+    }
+
+    func filteredToDos(selection: ListSelection) -> [ToDo] {
+        switch selection {
+        case .list(.inbox):
+            return database.toDos.filter { $0.parentProjectID == nil && $0.parentAreaID == nil && $0.status == .open }
+        case .list:
+            return database.toDos // For other default lists return all for now
+        case .project(let id):
+            return database.toDos.filter { $0.parentProjectID == id }
+        case .area(let id):
+            return database.toDos.filter { $0.parentAreaID == id }
+        }
+    }
+
+    func addTodo(to selection: ListSelection) {
+        var todo = ToDo(title: "New To-Do")
+        switch selection {
+        case .project(let id):
+            todo.parentProjectID = id
+        case .area(let id):
+            todo.parentAreaID = id
+        case .list:
+            break
+        }
+        database.toDos.append(todo)
+        save()
+    }
+
+    func toggleCompletion(for todoID: UUID) {
+        guard let index = database.toDos.firstIndex(where: { $0.id == todoID }) else { return }
+        if database.toDos[index].status == .completed {
+            database.toDos[index].status = .open
+            database.toDos[index].completionDate = nil
+        } else {
+            database.toDos[index].status = .completed
+            database.toDos[index].completionDate = Date()
+        }
+        save()
+    }
+
+    func deleteTodo(at offsets: IndexSet, selection: ListSelection) {
+        let tasks = filteredToDos(selection: selection)
+        let ids = offsets.map { tasks[$0].id }
+        database.toDos.removeAll { ids.contains($0.id) }
+        save()
+    }
+
+    private func save() {
+        Task { try? await PersistenceManager.shared.save(database) }
+    }
+}

--- a/Things4/Sources/MyApp/DefaultList.swift
+++ b/Things4/Sources/MyApp/DefaultList.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum DefaultList: String, CaseIterable, Identifiable {
+    case inbox
+    case today
+    case upcoming
+    case anytime
+    case someday
+    case logbook
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .inbox: return "Inbox"
+        case .today: return "Today"
+        case .upcoming: return "Upcoming"
+        case .anytime: return "Anytime"
+        case .someday: return "Someday"
+        case .logbook: return "Logbook"
+        }
+    }
+}

--- a/Things4/Sources/MyApp/ListSelection.swift
+++ b/Things4/Sources/MyApp/ListSelection.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Things4
+
+enum ListSelection: Hashable, Identifiable {
+    case list(DefaultList)
+    case area(UUID)
+    case project(UUID)
+
+    var id: String {
+        switch self {
+        case .list(let list):
+            return "list-\(list.rawValue)"
+        case .area(let id):
+            return "area-\(id.uuidString)"
+        case .project(let id):
+            return "project-\(id.uuidString)"
+        }
+    }
+
+    func title(in database: Database) -> String {
+        switch self {
+        case .list(let list):
+            return list.title
+        case .area(let id):
+            return database.areas.first(where: { $0.id == id })?.title ?? ""
+        case .project(let id):
+            return database.projects.first(where: { $0.id == id })?.title ?? ""
+        }
+    }
+}

--- a/Things4/Sources/MyApp/SampleData.swift
+++ b/Things4/Sources/MyApp/SampleData.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Things4
+
+struct SampleData {
+    static var database: Database = {
+        let areaHome = Area(title: "Home")
+        let areaWork = Area(title: "Work")
+
+        let projects = [
+            Project(title: "Chores", parentAreaID: areaHome.id),
+            Project(title: "Launch", parentAreaID: areaWork.id)
+        ]
+
+        let todos = [
+            ToDo(title: "Buy milk"),
+            ToDo(title: "Clean kitchen", parentProjectID: projects[0].id),
+            ToDo(title: "Prep presentation", parentProjectID: projects[1].id)
+        ]
+
+        return Database(toDos: todos, projects: projects, areas: [areaHome, areaWork])
+    }()
+}

--- a/Things4/Sources/MyApp/ToDoListView.swift
+++ b/Things4/Sources/MyApp/ToDoListView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import Things4
+
+struct ToDoListView: View {
+    @ObservedObject var store: DatabaseStore
+    var selection: ListSelection
+
+    var body: some View {
+        List {
+            ForEach(store.filteredToDos(selection: selection)) { todo in
+                HStack {
+                    Image(systemName: todo.status == .completed ? "checkmark.circle.fill" : "circle")
+                        .onTapGesture { store.toggleCompletion(for: todo.id) }
+                    Text(todo.title)
+                        .strikethrough(todo.status == .completed)
+                        .foregroundColor(todo.status == .completed ? .gray : .primary)
+                }
+            }
+            .onDelete { offsets in
+                store.deleteTodo(at: offsets, selection: selection)
+            }
+        }
+        .navigationTitle(selection.title(in: store.database))
+        .toolbar { Button(action: { store.addTodo(to: selection) }) { Image(systemName: "plus") } }
+    }
+}
+
+#Preview {
+    ToDoListView(store: DatabaseStore(), selection: .list(.inbox))
+}

--- a/Things4Tests/DataModelTests.swift
+++ b/Things4Tests/DataModelTests.swift
@@ -1,63 +1,33 @@
 import Foundation
-<<<<<<< codex/refer-to-bible.txt-for-instructions
 import XCTest
 @testable import Things4
 
 final class DataModelTests: XCTestCase {
-=======
-import Testing
-@testable import Things4
-
-struct DataModelTests {
-    @Test
->>>>>>> main
     func testModelCodable() throws {
         let todo = ToDo(title: "Test")
         let data = try JSONEncoder().encode(todo)
         let decoded = try JSONDecoder().decode(ToDo.self, from: data)
-<<<<<<< codex/refer-to-bible.txt-for-instructions
         XCTAssertEqual(decoded.title, todo.title)
     }
 
-=======
-        #expect(decoded.title == todo.title)
-    }
-
-    @Test
->>>>>>> main
     func testProjectCodable() throws {
         let project = Project(title: "Project")
         let data = try JSONEncoder().encode(project)
         let decoded = try JSONDecoder().decode(Project.self, from: data)
-<<<<<<< codex/refer-to-bible.txt-for-instructions
         XCTAssertEqual(decoded.title, project.title)
     }
 
-=======
-        #expect(decoded.title == project.title)
-    }
-
-    @Test
->>>>>>> main
     func testAreaCodable() throws {
         let area = Area(title: "Area")
         let data = try JSONEncoder().encode(area)
         let decoded = try JSONDecoder().decode(Area.self, from: data)
-<<<<<<< codex/refer-to-bible.txt-for-instructions
         XCTAssertEqual(decoded.title, area.title)
     }
 
-=======
-        #expect(decoded.title == area.title)
-    }
-
-    @Test
->>>>>>> main
     func testHeadingCodable() throws {
         let heading = Heading(title: "Heading", parentProjectID: UUID())
         let data = try JSONEncoder().encode(heading)
         let decoded = try JSONDecoder().decode(Heading.self, from: data)
-<<<<<<< codex/refer-to-bible.txt-for-instructions
         XCTAssertEqual(decoded.title, heading.title)
     }
 
@@ -66,16 +36,5 @@ struct DataModelTests {
         let data = try JSONEncoder().encode(tag)
         let decoded = try JSONDecoder().decode(Tag.self, from: data)
         XCTAssertEqual(decoded.name, tag.name)
-=======
-        #expect(decoded.title == heading.title)
-    }
-
-    @Test
-    func testTagCodable() throws {
-        let tag = Things4.Tag(name: "Tag")
-        let data = try JSONEncoder().encode(tag)
-        let decoded = try JSONDecoder().decode(Things4.Tag.self, from: data)
-        #expect(decoded.name == tag.name)
->>>>>>> main
     }
 }


### PR DESCRIPTION
## Summary
- exclude SwiftUI app files from library target
- add `DefaultList` enumeration and sample data
- implement sidebar navigation in `ContentView`
- add `ToDoListView` with basic CRUD operations
- load data via `DatabaseStore` using `PersistenceManager`

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6851a62deb248331a196709ef28e0e3b